### PR TITLE
[ci] Specify repository and ref explicitly on checkout

### DIFF
--- a/.github/workflows/build_test.yaml
+++ b/.github/workflows/build_test.yaml
@@ -39,6 +39,8 @@ jobs:
       - name: Checkout repository
         uses: actions/checkout@v4
         with:
+          ref: ${{github.event.pull_request.head.ref}}
+          repository: ${{github.event.pull_request.head.repo.full_name}}
           fetch-depth: 0
           submodules: "recursive"
 


### PR DESCRIPTION
For pull requests originating from forked repositories, the main repository is used, and CI is triggered
on the intended target branch.
This update introduces the specification of the repository and ref in the GitHub Actions workflow, ensuring that CI is triggered on the correct branch.
There is no impact on builds from the main repository.